### PR TITLE
feat(download): implement sequential download manager for single-tab downloads

### DIFF
--- a/lib/download-manager.js
+++ b/lib/download-manager.js
@@ -1,28 +1,294 @@
 /**
- * Bandcamp Downloader - Download Manager
- * Handles sequential download processing and queue management
- * 
- * This module will be implemented in Phase 4
+ * Trail Mix - Download Manager
+ * Handles download processing and queue management
+ * Phase 4: Core Download Engine Implementation
  */
 
-// TODO: Implement download functionality
-// - Sequential download queue
-// - Chrome Downloads API integration
-// - Progress tracking
-// - Error handling and retry logic
-// - Resume functionality
-// - Rate limiting
+/**
+ * DownloadManager Class
+ * Manages individual album downloads from Bandcamp
+ */
+class DownloadManager {
+  constructor() {
+    // Track the currently active download
+    this.activeDownload = null;
 
-console.log('Download Manager module loaded (placeholder)');
+    // Track download progress
+    this.downloadProgress = {};
 
-// Export placeholder
+    // Progress callback
+    this.onProgress = null;
+
+    // Set up Chrome Downloads API listener
+    if (typeof chrome !== 'undefined' && chrome.downloads) {
+      chrome.downloads.onChanged.addListener(this.handleDownloadChange.bind(this));
+    }
+
+    // Check interval for download link readiness (ms)
+    this.checkInterval = 2000;
+
+    // Timeout for waiting for download link (ms)
+    this.downloadTimeout = 30000;
+  }
+
+  /**
+   * Download a single purchase item
+   * @param {Object} purchaseItem - The item to download
+   * @param {string} purchaseItem.title - Album/track title
+   * @param {string} purchaseItem.artist - Artist name
+   * @param {string} purchaseItem.downloadUrl - Bandcamp download page URL
+   * @returns {Promise} Resolves when download completes or rejects on error
+   */
+  async download(purchaseItem) {
+    // Clear any existing download
+    if (this.activeDownload) {
+      throw new Error('Download already in progress');
+    }
+
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Store download info
+        this.activeDownload = {
+          purchaseItem,
+          status: 'preparing',
+          tabId: null,
+          downloadId: null,
+          promise: { resolve, reject }
+        };
+
+        // Step 1: Open download page in inactive tab
+        const tab = await chrome.tabs.create({
+          url: purchaseItem.downloadUrl,
+          active: false
+        });
+
+        this.activeDownload.tabId = tab.id;
+        console.log(`Opened tab ${tab.id} for ${purchaseItem.title}`);
+
+        // Step 2: Monitor tab for download link readiness
+        this.startMonitoring();
+
+      } catch (error) {
+        console.error('Failed to start download:', error);
+        this.cleanup();
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Start monitoring the tab for download link readiness
+   */
+  startMonitoring() {
+    if (!this.activeDownload) return;
+
+    let checkCount = 0;
+    const maxChecks = Math.floor(this.downloadTimeout / this.checkInterval);
+
+    const checkForDownload = async () => {
+      if (!this.activeDownload) return;
+
+      checkCount++;
+
+      try {
+        // Send message to content script to check if download is ready
+        const response = await this.sendMessageToTab(
+          this.activeDownload.tabId,
+          { type: 'CHECK_DOWNLOAD_READY' }
+        );
+
+        if (response && response.ready && response.url) {
+          console.log(`Download link ready: ${response.url}`);
+
+          // Step 3: Extract and initiate download
+          await this.initiateDownload(response.url);
+        } else if (checkCount >= maxChecks) {
+          // Timeout
+          throw new Error('Download preparation timeout');
+        } else {
+          // Check again after interval
+          setTimeout(checkForDownload, this.checkInterval);
+        }
+
+      } catch (error) {
+        console.error('Error checking download readiness:', error);
+        this.handleError(error);
+      }
+    };
+
+    // Start checking
+    setTimeout(checkForDownload, this.checkInterval);
+  }
+
+  /**
+   * Send message to tab and return response
+   */
+  sendMessageToTab(tabId, message) {
+    return new Promise((resolve) => {
+      chrome.tabs.sendMessage(tabId, message, (response) => {
+        resolve(response || {});
+      });
+    });
+  }
+
+  /**
+   * Initiate download using Chrome Downloads API
+   */
+  async initiateDownload(downloadUrl) {
+    if (!this.activeDownload) return;
+
+    try {
+      // Step 4: Start download using Chrome Downloads API
+      const downloadId = await chrome.downloads.download({
+        url: downloadUrl,
+        saveAs: false  // Don't prompt for each file
+      });
+
+      this.activeDownload.downloadId = downloadId;
+      this.activeDownload.status = 'downloading';
+
+      console.log(`Started download ${downloadId} for ${this.activeDownload.purchaseItem.title}`);
+
+      // Step 5: Close the tab
+      if (this.activeDownload.tabId) {
+        try {
+          await chrome.tabs.remove(this.activeDownload.tabId);
+          console.log(`Closed tab ${this.activeDownload.tabId}`);
+        } catch (error) {
+          console.warn('Failed to close tab:', error);
+        }
+      }
+
+    } catch (error) {
+      console.error('Failed to initiate download:', error);
+      this.handleError(error);
+    }
+  }
+
+  /**
+   * Handle download state changes from Chrome Downloads API
+   */
+  handleDownloadChange(downloadDelta) {
+    if (!this.activeDownload || downloadDelta.id !== this.activeDownload.downloadId) {
+      return;
+    }
+
+    // Track progress
+    if (downloadDelta.bytesReceived || downloadDelta.totalBytes) {
+      const bytesReceived = downloadDelta.bytesReceived?.current ||
+                           this.downloadProgress[downloadDelta.id]?.bytesReceived || 0;
+      const totalBytes = downloadDelta.totalBytes?.current ||
+                        this.activeDownload.totalBytes || 0;
+
+      if (!this.activeDownload.totalBytes && totalBytes > 0) {
+        this.activeDownload.totalBytes = totalBytes;
+      }
+
+      const percentComplete = totalBytes > 0 ? Math.round((bytesReceived / totalBytes) * 100) : 0;
+
+      this.downloadProgress[downloadDelta.id] = {
+        downloadId: downloadDelta.id,
+        bytesReceived,
+        totalBytes,
+        percentComplete
+      };
+
+      // Call progress callback if set
+      if (this.onProgress) {
+        this.onProgress(this.downloadProgress[downloadDelta.id]);
+      }
+
+      console.log(`Download progress: ${percentComplete}% (${bytesReceived}/${totalBytes})`);
+    }
+
+    // Handle state changes
+    if (downloadDelta.state) {
+      if (downloadDelta.state.current === 'complete') {
+        console.log(`Download completed: ${this.activeDownload.purchaseItem.title}`);
+        this.handleCompletion();
+      } else if (downloadDelta.state.current === 'interrupted') {
+        console.error(`Download interrupted: ${this.activeDownload.purchaseItem.title}`);
+        this.handleError(new Error('Download interrupted'));
+      }
+    }
+  }
+
+  /**
+   * Handle successful download completion
+   */
+  handleCompletion() {
+    if (this.activeDownload && this.activeDownload.promise) {
+      this.activeDownload.promise.resolve({
+        success: true,
+        purchaseItem: this.activeDownload.purchaseItem
+      });
+    }
+    this.cleanup();
+  }
+
+  /**
+   * Handle download error
+   */
+  handleError(error) {
+    if (this.activeDownload) {
+      // Close tab if still open
+      if (this.activeDownload.tabId && chrome.tabs && chrome.tabs.remove) {
+        const removePromise = chrome.tabs.remove(this.activeDownload.tabId);
+        if (removePromise && typeof removePromise.catch === 'function') {
+          removePromise.catch(() => {});
+        }
+      }
+
+      // Reject the promise
+      if (this.activeDownload.promise) {
+        this.activeDownload.promise.reject(error);
+      }
+    }
+    this.cleanup();
+  }
+
+  /**
+   * Cancel the current download
+   */
+  cancel() {
+    if (this.activeDownload) {
+      // Cancel Chrome download if in progress
+      if (this.activeDownload.downloadId && chrome.downloads && chrome.downloads.cancel) {
+        const cancelPromise = chrome.downloads.cancel(this.activeDownload.downloadId);
+        if (cancelPromise && typeof cancelPromise.catch === 'function') {
+          cancelPromise.catch(() => {});
+        }
+      }
+
+      // Close tab if still open
+      if (this.activeDownload.tabId && chrome.tabs && chrome.tabs.remove) {
+        const removePromise = chrome.tabs.remove(this.activeDownload.tabId);
+        if (removePromise && typeof removePromise.catch === 'function') {
+          removePromise.catch(() => {});
+        }
+      }
+
+      // Reject the promise
+      if (this.activeDownload.promise) {
+        this.activeDownload.promise.reject(new Error('Download cancelled'));
+      }
+    }
+    this.cleanup();
+  }
+
+  /**
+   * Clean up after download
+   */
+  cleanup() {
+    this.activeDownload = null;
+    // Keep progress history for completed downloads
+  }
+}
+
+// Export for both Node.js (tests) and browser environments
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {
-    // Placeholder exports
-  };
-} else {
-  window.BandcampDownloadManager = {
-    // Placeholder exports
-  };
+  module.exports = DownloadManager;
+} else if (typeof window !== 'undefined') {
+  window.DownloadManager = DownloadManager;
 }
 

--- a/lib/download-manager.js
+++ b/lib/download-manager.js
@@ -138,6 +138,11 @@ class DownloadManager {
     if (!this.activeDownload) return;
 
     try {
+      // Validate download URL is from trusted Bandcamp domain
+      if (!this.isValidDownloadUrl(downloadUrl)) {
+        throw new Error(`Invalid download URL: ${downloadUrl}. Must be from bcbits.com domain.`);
+      }
+
       // Step 4: Start download using Chrome Downloads API
       const downloadId = await chrome.downloads.download({
         url: downloadUrl,
@@ -218,6 +223,11 @@ class DownloadManager {
    */
   handleCompletion() {
     if (this.activeDownload && this.activeDownload.promise) {
+      // Clean up progress tracking for completed download
+      if (this.activeDownload.downloadId) {
+        delete this.downloadProgress[this.activeDownload.downloadId];
+      }
+
       this.activeDownload.promise.resolve({
         success: true,
         purchaseItem: this.activeDownload.purchaseItem
@@ -231,6 +241,11 @@ class DownloadManager {
    */
   handleError(error) {
     if (this.activeDownload) {
+      // Clean up progress tracking for failed download
+      if (this.activeDownload.downloadId) {
+        delete this.downloadProgress[this.activeDownload.downloadId];
+      }
+
       // Close tab if still open
       if (this.activeDownload.tabId && chrome.tabs && chrome.tabs.remove) {
         const removePromise = chrome.tabs.remove(this.activeDownload.tabId);
@@ -252,6 +267,11 @@ class DownloadManager {
    */
   cancel() {
     if (this.activeDownload) {
+      // Clean up progress tracking for cancelled download
+      if (this.activeDownload.downloadId) {
+        delete this.downloadProgress[this.activeDownload.downloadId];
+      }
+
       // Cancel Chrome download if in progress
       if (this.activeDownload.downloadId && chrome.downloads && chrome.downloads.cancel) {
         const cancelPromise = chrome.downloads.cancel(this.activeDownload.downloadId);
@@ -282,6 +302,28 @@ class DownloadManager {
   cleanup() {
     this.activeDownload = null;
     // Keep progress history for completed downloads
+  }
+
+  /**
+   * Validate download URL is from trusted Bandcamp domain
+   * @param {string} url - URL to validate
+   * @returns {boolean} true if URL is valid
+   */
+  isValidDownloadUrl(url) {
+    if (!url || typeof url !== 'string') {
+      return false;
+    }
+
+    try {
+      const urlObj = new URL(url);
+      // Allow downloads only from Bandcamp's content delivery network
+      // bcbits.com is Bandcamp's CDN domain for media files
+      return urlObj.protocol === 'https:' &&
+             urlObj.hostname.endsWith('.bcbits.com');
+    } catch (error) {
+      // Invalid URL
+      return false;
+    }
   }
 }
 

--- a/tests/unit/download-manager.test.js
+++ b/tests/unit/download-manager.test.js
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for Download Manager
+ * Tests Phase 4 Task 4.1: Core Download Engine
+ */
+
+// Mock Chrome APIs
+const mockChrome = {
+  tabs: {
+    create: jest.fn(),
+    remove: jest.fn(() => Promise.resolve()),
+    sendMessage: jest.fn(),
+    onUpdated: {
+      addListener: jest.fn()
+    }
+  },
+  downloads: {
+    download: jest.fn(),
+    cancel: jest.fn(() => Promise.resolve()),
+    onChanged: {
+      addListener: jest.fn()
+    }
+  },
+  runtime: {
+    lastError: null
+  }
+};
+
+// Set up global chrome mock
+global.chrome = mockChrome;
+
+// Import after setting up mocks
+const DownloadManager = require('../../lib/download-manager.js');
+
+describe('DownloadManager', () => {
+  let downloadManager;
+  let mockPurchaseItem;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Create new instance
+    downloadManager = new DownloadManager();
+
+    // Create mock purchase item
+    mockPurchaseItem = {
+      title: 'Test Album',
+      artist: 'Test Artist',
+      downloadUrl: 'https://bandcamp.com/download/album?id=123456',
+      albumArt: 'https://example.com/artwork.jpg'
+    };
+  });
+
+  describe('Single Download Functionality', () => {
+    test('should create DownloadManager instance', () => {
+      expect(downloadManager).toBeDefined();
+      expect(downloadManager.activeDownload).toBeNull();
+      expect(downloadManager.downloadProgress).toEqual({});
+    });
+
+    test('should open download page in inactive tab', async () => {
+      const mockTabId = 123;
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Should create tab with download URL
+      expect(mockChrome.tabs.create).toHaveBeenCalledWith({
+        url: mockPurchaseItem.downloadUrl,
+        active: false
+      });
+
+      // Cleanup
+      downloadManager.cancel();
+    });
+
+    test('should monitor tab for download link readiness', async () => {
+      const mockTabId = 123;
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+
+      // Mock sendMessage to never be ready
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          callback({ ready: false });
+        }
+      });
+
+      // Start download (don't await - we're testing the monitoring state)
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Allow promise to settle
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Should set up monitoring for the tab
+      expect(downloadManager.activeDownload).toBeTruthy();
+      expect(downloadManager.activeDownload.tabId).toBe(mockTabId);
+      expect(downloadManager.activeDownload.status).toBe('preparing');
+
+      // Cleanup - cancel and catch the rejection
+      downloadManager.cancel();
+      await expect(downloadPromise).rejects.toThrow('Download cancelled');
+    });
+
+    test('should extract download link when ready', async () => {
+      const mockTabId = 123;
+      const mockDownloadUrl = 'https://p4.bcbits.com/download/track/abc123';
+      const mockDownloadId = 456;
+
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+      mockChrome.downloads.download.mockResolvedValue(mockDownloadId);
+      mockChrome.tabs.remove.mockResolvedValue();
+
+      // Simulate content script response with download link ready
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          setTimeout(() => callback({ ready: true, url: mockDownloadUrl }), 0);
+        }
+      });
+
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Wait for monitoring to start and check to happen
+      await new Promise(resolve => setTimeout(resolve, 2500));
+
+      // Should have sent message to check if download is ready
+      expect(mockChrome.tabs.sendMessage).toHaveBeenCalledWith(
+        mockTabId,
+        { type: 'CHECK_DOWNLOAD_READY' },
+        expect.any(Function)
+      );
+
+      // Cleanup
+      downloadManager.cancel();
+    });
+
+    test('should initiate download using Chrome Downloads API', async () => {
+      const mockTabId = 123;
+      const mockDownloadUrl = 'https://p4.bcbits.com/download/track/abc123';
+      const mockDownloadId = 456;
+
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+      mockChrome.downloads.download.mockResolvedValue(mockDownloadId);
+      mockChrome.tabs.remove.mockResolvedValue();
+
+      // Simulate content script response with download link ready immediately
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          // Return ready immediately
+          callback({ ready: true, url: mockDownloadUrl });
+        }
+      });
+
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Wait for monitoring cycle to complete
+      await new Promise(resolve => setTimeout(resolve, 2500));
+
+      // Should have initiated download
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith({
+        url: mockDownloadUrl,
+        saveAs: false
+      });
+
+      // Should track the download ID
+      expect(downloadManager.activeDownload.downloadId).toBe(mockDownloadId);
+
+      // Cleanup
+      downloadManager.cancel();
+    });
+
+    test('should close tab after initiating download', async () => {
+      const mockTabId = 123;
+      const mockDownloadUrl = 'https://p4.bcbits.com/download/track/abc123';
+      const mockDownloadId = 456;
+
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+      mockChrome.downloads.download.mockResolvedValue(mockDownloadId);
+      mockChrome.tabs.remove.mockResolvedValue();
+
+      // Simulate content script response with download link ready
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          callback({ ready: true, url: mockDownloadUrl });
+        }
+      });
+
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Wait for monitoring and download initiation to complete
+      await new Promise(resolve => setTimeout(resolve, 2500));
+
+      // Should have closed the tab
+      expect(mockChrome.tabs.remove).toHaveBeenCalledWith(mockTabId);
+
+      // Cleanup
+      downloadManager.cancel();
+    });
+
+    test('should track download progress', async () => {
+      const mockDownloadId = 456;
+      const progressCallback = jest.fn();
+
+      // Set up progress listener
+      downloadManager.onProgress = progressCallback;
+
+      // Simulate progress update
+      const progressDelta = {
+        id: mockDownloadId,
+        state: { current: 'in_progress' },
+        bytesReceived: { current: 5000000 },
+        totalBytes: { current: 10000000 }
+      };
+
+      // Get the listener that was registered
+      const onChangedListener = mockChrome.downloads.onChanged.addListener.mock.calls[0]?.[0];
+
+      if (onChangedListener) {
+        // Simulate download with active download
+        downloadManager.activeDownload = {
+          downloadId: mockDownloadId,
+          totalBytes: 10000000
+        };
+
+        onChangedListener(progressDelta);
+
+        // Should have called progress callback
+        expect(progressCallback).toHaveBeenCalledWith({
+          downloadId: mockDownloadId,
+          bytesReceived: 5000000,
+          totalBytes: 10000000,
+          percentComplete: 50
+        });
+      }
+    });
+
+    test('should handle download completion', async () => {
+      const mockDownloadId = 456;
+
+      // Get the listener that was registered
+      const onChangedListener = mockChrome.downloads.onChanged.addListener.mock.calls[0]?.[0];
+
+      if (onChangedListener) {
+        // Simulate download with active download
+        const mockResolve = jest.fn();
+        const mockReject = jest.fn();
+
+        downloadManager.activeDownload = {
+          downloadId: mockDownloadId,
+          purchaseItem: mockPurchaseItem,
+          promise: {
+            resolve: mockResolve,
+            reject: mockReject
+          }
+        };
+
+        // Simulate completion
+        const completeDelta = {
+          id: mockDownloadId,
+          state: { current: 'complete' }
+        };
+
+        onChangedListener(completeDelta);
+
+        // Should resolve the promise
+        expect(mockResolve).toHaveBeenCalled();
+
+        // Should clear active download
+        expect(downloadManager.activeDownload).toBeNull();
+      }
+    });
+
+    test('should handle download errors', async () => {
+      const mockTabId = 123;
+
+      mockChrome.tabs.create.mockRejectedValue(new Error('Tab creation failed'));
+
+      // Should reject the promise
+      await expect(downloadManager.download(mockPurchaseItem)).rejects.toThrow('Tab creation failed');
+
+      // Should clear active download
+      expect(downloadManager.activeDownload).toBeNull();
+    });
+
+    test('should timeout if download link never appears', async () => {
+      jest.useFakeTimers();
+
+      const mockTabId = 123;
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+
+      // Simulate content script always returning "not ready"
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          callback({ ready: false });
+        }
+      });
+
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Fast-forward time to trigger timeout
+      jest.advanceTimersByTime(31000); // 30 second timeout + buffer
+
+      // Process microtasks
+      await Promise.resolve();
+
+      // Should reject with timeout error
+      await expect(downloadPromise).rejects.toThrow('Download preparation timeout');
+
+      jest.useRealTimers();
+    }, 10000); // Increase test timeout
+  });
+
+  describe('Acceptance Criteria', () => {
+    test('AC4.1.1: Successfully downloads a single purchase item', async () => {
+      const mockTabId = 123;
+      const mockDownloadUrl = 'https://p4.bcbits.com/download/track/abc123';
+      const mockDownloadId = 456;
+
+      mockChrome.tabs.create.mockResolvedValue({ id: mockTabId });
+      mockChrome.downloads.download.mockResolvedValue(mockDownloadId);
+      mockChrome.tabs.remove.mockResolvedValue();
+
+      mockChrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        if (message.type === 'CHECK_DOWNLOAD_READY') {
+          callback({ ready: true, url: mockDownloadUrl });
+        }
+      });
+
+      // Start download
+      const downloadPromise = downloadManager.download(mockPurchaseItem);
+
+      // Wait for full download cycle
+      await new Promise(resolve => setTimeout(resolve, 2500));
+
+      // Verify complete flow
+      expect(mockChrome.tabs.create).toHaveBeenCalled();
+      expect(mockChrome.tabs.sendMessage).toHaveBeenCalled();
+      expect(mockChrome.downloads.download).toHaveBeenCalled();
+      expect(mockChrome.tabs.remove).toHaveBeenCalled();
+
+      downloadManager.cancel();
+    }, 10000);
+  });
+});

--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -245,14 +245,17 @@ describe('Service Worker', () => {
     });
     
     test('should handle unhandled promise rejections', () => {
-      // Mock PromiseRejectionEvent for Node.js environment
       if (self && typeof self.dispatchEvent === 'function') {
-        const rejectionEvent = {
-          type: 'unhandledrejection',
-          reason: new Error('Test rejection'),
-          promise: Promise.resolve(),
-          preventDefault: jest.fn()
-        };
+        const rejectionEvent = new Event('unhandledrejection');
+        Object.defineProperty(rejectionEvent, 'reason', {
+          value: new Error('Test rejection'),
+          configurable: true
+        });
+        Object.defineProperty(rejectionEvent, 'promise', {
+          value: Promise.resolve(),
+          configurable: true
+        });
+
         expect(() => { self.dispatchEvent(rejectionEvent); }).not.toThrow();
       }
     });


### PR DESCRIPTION
## Summary
Implements Phase 4 Task 4.1: Core Download Engine with a thin slice approach focusing on sequential downloads that open only one tab at a time.

## Problem
Previously, multiple tabs would open simultaneously when starting downloads after purchase discovery, which could overwhelm the browser and create a poor user experience.

## Solution
- Created a new `DownloadManager` class that handles downloads one at a time
- Replaced the parallel download system with sequential processing
- Each download now:
  1. Opens ONE inactive tab with the download page
  2. Monitors for the download link to be ready (waits for "Preparing" state)
  3. Extracts the actual download URL
  4. Initiates download via Chrome Downloads API
  5. Closes the tab immediately
  6. Moves to the next item after a short delay

## Changes
- ✅ Created `lib/download-manager.js` with single download capability
- ✅ Added `CHECK_DOWNLOAD_READY` handler to content script
- ✅ Updated service worker to use DownloadManager for all downloads
- ✅ Added comprehensive unit tests (11 tests)
- ✅ Deprecated old parallel download code (commented out for reference)

## Testing
- Unit tests: `npm test -- tests/unit/download-manager.test.js`
- Manual testing: Click "Start Download" in popup - should see only one tab at a time

## Benefits
- **Better UX**: Only one tab opens at a time
- **Resource efficient**: Doesn't overwhelm the browser
- **Predictable**: Sequential processing is easier to debug
- **Maintainable**: All download logic centralized in DownloadManager

🤖 Generated with [Claude Code](https://claude.ai/code)