### PR TITLE
Save Bandcamp downloads under TrailMix/ subfolder

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -48,22 +48,45 @@ try {
           return;
         }
 
-        // Use Chrome's suggested path but prefix with our folder
-        const suggested = (item && item.filename) ? String(item.filename) : '';
-        const normalized = suggested.replace(/^\/+/, '');
+        // Use Chrome's suggested filename when available
+        const suggestedRaw = (item && item.filename) ? String(item.filename) : '';
+
+        // Remove any leading slashes
+        const noLeadingSlash = suggestedRaw.replace(/^\/+/, '');
+
+        // Sanitize path segments to prevent traversal and illegal characters
+        const illegalRe = /[<>:"\\|?*]/g; // keep forward slash for subfolders
+        const segments = noLeadingSlash
+          .split('/')
+          .filter(Boolean)
+          .filter(seg => seg !== '.' && seg !== '..')
+          .map(seg => seg.replace(illegalRe, '_'));
+
+        let sanitizedPath = segments.join('/');
+
+        // Fallback to URL last segment if needed
+        if (!sanitizedPath) {
+          try {
+            const last = new URL(url).pathname.split('/').filter(Boolean).pop();
+            sanitizedPath = (last || '').replace(illegalRe, '_');
+          } catch (_) {
+            // As a last resort, use timestamp-based name
+            sanitizedPath = `download-${Date.now()}`;
+          }
+        }
 
         // Avoid double-prefixing if already under TrailMix/
-        const target = normalized.startsWith('TrailMix/')
-          ? normalized
-          : `TrailMix/${normalized || (new URL(url).pathname.split('/').pop() || 'download')}`;
+        const alreadyPrefixed = sanitizedPath.startsWith('TrailMix/');
+        const target = alreadyPrefixed ? sanitizedPath : `TrailMix/${sanitizedPath}`;
 
         // Ask Chrome to save under the TrailMix subdirectory; Chrome will
         // create the directory automatically if it does not exist.
         if (typeof suggest === 'function') {
           suggest({ filename: target, conflictAction: 'uniquify' });
         }
-      } catch (_) {
-        // Swallow errors to avoid interrupting downloads
+      } catch (e) {
+        // Log minimally to aid diagnostics without interrupting downloads
+        try { console.warn('[TrailMix] onDeterminingFilename error:', e && e.message ? e.message : String(e)); } catch(_) {}
       }
     });
   }

--- a/tests/mocks/chrome-mock.js
+++ b/tests/mocks/chrome-mock.js
@@ -94,6 +94,10 @@ const chromeMock = {
       addListener: jest.fn(),
       removeListener: jest.fn()
     },
+    onDeterminingFilename: {
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    },
     search: jest.fn(),
     cancel: jest.fn()
   },
@@ -121,4 +125,3 @@ const chromeMock = {
 };
 
 module.exports = chromeMock;
-

--- a/tests/unit/filename-listener.test.js
+++ b/tests/unit/filename-listener.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for downloads.onDeterminingFilename listener
+ */
+
+const chromeMock = require('../mocks/chrome-mock');
+
+describe('Downloads filename listener', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.chrome = chromeMock;
+    // Load service worker fresh to register listener
+    delete require.cache[require.resolve('../../background/service-worker.js')];
+    require('../../background/service-worker.js');
+  });
+
+  function getListener() {
+    const calls = chrome.downloads.onDeterminingFilename.addListener.mock.calls;
+    return calls.length ? calls[0][0] : null;
+  }
+
+  test('prefixes bcbits downloads with TrailMix/', () => {
+    const listener = getListener();
+    expect(listener).toBeTruthy();
+    const suggest = jest.fn();
+
+    listener({
+      url: 'https://p4.bcbits.com/download/somefile.mp3',
+      filename: 'somefile.mp3'
+    }, suggest);
+
+    expect(suggest).toHaveBeenCalledWith(expect.objectContaining({
+      filename: 'TrailMix/somefile.mp3'
+    }));
+  });
+
+  test('does not affect non-bcbits downloads', () => {
+    const listener = getListener();
+    const suggest = jest.fn();
+
+    listener({
+      url: 'https://example.com/file.mp3',
+      filename: 'file.mp3'
+    }, suggest);
+
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  test('prevents path traversal and sanitizes segments', () => {
+    const listener = getListener();
+    const suggest = jest.fn();
+
+    listener({
+      url: 'https://p4.bcbits.com/download/track.mp3',
+      filename: '/evil/../../trac<>k.mp3'
+    }, suggest);
+
+    expect(suggest).toHaveBeenCalled();
+    const arg = suggest.mock.calls[0][0];
+    expect(arg.filename.startsWith('TrailMix/')).toBe(true);
+    expect(arg.filename.includes('..')).toBe(false);
+    expect(arg.filename.includes('<')).toBe(false);
+    expect(arg.filename.includes('>')).toBe(false);
+  });
+
+  test('avoids double prefix when already under TrailMix/', () => {
+    const listener = getListener();
+    const suggest = jest.fn();
+
+    listener({
+      url: 'https://p4.bcbits.com/download/track.mp3',
+      filename: 'TrailMix/already.mp3'
+    }, suggest);
+
+    expect(suggest).toHaveBeenCalledWith(expect.objectContaining({
+      filename: 'TrailMix/already.mp3'
+    }));
+  });
+});
+


### PR DESCRIPTION
This PR routes all Bandcamp CDN file downloads to a `TrailMix/` subdirectory using the Downloads API:\n\n- Adds a guarded `chrome.downloads.onDeterminingFilename` listener in the service worker\n- Prefixes filenames for `*.bcbits.com` downloads with `TrailMix/`\n- Uses `conflictAction: uniquify` to avoid collisions\n- Relies on Chrome to auto-create the `TrailMix` directory on first save\n\nThis keeps non-Bandcamp downloads unchanged and requires no user prompts.