### PR TITLE
Remove Settings UI from popup

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -215,66 +215,6 @@ body {
   flex: none;
 }
 
-/* Settings Section */
-.settings-section {
-  margin-bottom: 16px;
-}
-
-.settings-details summary {
-  cursor: pointer;
-  font-weight: 500;
-  padding: 8px 0;
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.settings-content {
-  padding: 12px 0;
-}
-
-.setting-item {
-  margin-bottom: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.setting-item:last-child {
-  margin-bottom: 0;
-}
-
-.setting-item label {
-  font-size: 12px;
-  font-weight: 500;
-  color: #555;
-}
-
-.setting-item input[type="text"],
-.setting-item input[type="number"] {
-  padding: 6px 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 12px;
-}
-
-.setting-item input[type="checkbox"] {
-  margin-right: 6px;
-}
-
-.setting-item:has(input[type="text"]) {
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-}
-
-.setting-item:has(input[type="text"]) label {
-  flex: none;
-  min-width: 120px;
-}
-
-.setting-item:has(input[type="text"]) input {
-  flex: 1;
-}
-
 /* Log Section */
 .log-section {
   margin-bottom: 16px;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -54,39 +54,6 @@
       </div>
     </section>
 
-    <!-- Settings -->
-    <section class="settings-section">
-      <details class="settings-details">
-        <summary>Settings</summary>
-        <div class="settings-content">
-          <div class="setting-item">
-            <label for="downloadLocation">Download Location:</label>
-            <input type="text" id="downloadLocation" placeholder="Browser default" readonly>
-            <button class="btn btn-small" id="selectLocationBtn">Choose</button>
-          </div>
-          
-          <div class="setting-item">
-            <label for="downloadDelay">Delay between downloads (seconds):</label>
-            <input type="number" id="downloadDelay" min="1" max="60" value="2">
-          </div>
-          
-          <div class="setting-item">
-            <label>
-              <input type="checkbox" id="embedMetadata" checked>
-              Embed metadata in files
-            </label>
-          </div>
-          
-          <div class="setting-item">
-            <label>
-              <input type="checkbox" id="embedArtwork" checked>
-              Embed album artwork
-            </label>
-          </div>
-        </div>
-      </details>
-    </section>
-
     <!-- Status Log -->
     <section class="log-section">
       <details class="log-details">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -24,11 +24,6 @@ async function initializePopup() {
     startBtn: document.getElementById('startBtn'),
     pauseBtn: document.getElementById('pauseBtn'),
     stopBtn: document.getElementById('stopBtn'),
-    downloadLocation: document.getElementById('downloadLocation'),
-    selectLocationBtn: document.getElementById('selectLocationBtn'),
-    downloadDelay: document.getElementById('downloadDelay'),
-    embedMetadata: document.getElementById('embedMetadata'),
-    embedArtwork: document.getElementById('embedArtwork'),
     logContent: document.getElementById('logContent'),
     clearLogBtn: document.getElementById('clearLogBtn')
   };
@@ -51,12 +46,6 @@ function setupEventListeners() {
   elements.stopBtn.addEventListener('click', handleStopDownload);
   elements.loginBtn.addEventListener('click', handleLogin);
 
-  // Settings
-  elements.selectLocationBtn.addEventListener('click', handleSelectLocation);
-  elements.downloadDelay.addEventListener('change', handleSettingsChange);
-  elements.embedMetadata.addEventListener('change', handleSettingsChange);
-  elements.embedArtwork.addEventListener('change', handleSettingsChange);
-  
   // Log
   elements.clearLogBtn.addEventListener('click', handleClearLog);
 }
@@ -66,13 +55,7 @@ async function loadInitialState() {
     // Get extension status and settings
     const response = await sendMessageToBackground({ type: 'GET_EXTENSION_STATUS' });
 
-    if (response.settings) {
-      // Load settings into UI
-      elements.downloadLocation.value = response.settings.downloadLocation || 'Browser default';
-      elements.downloadDelay.value = response.settings.downloadDelay / 1000 || 2;
-      elements.embedMetadata.checked = response.settings.metadataEmbedding !== false;
-      elements.embedArtwork.checked = response.settings.artworkEmbedding !== false;
-    }
+    // Settings are loaded but no longer displayed in UI
 
     // Restore download state if there's an active or paused queue
     if (response.downloadState) {
@@ -274,28 +257,6 @@ async function handleLogin() {
     window.close();
   } catch (error) {
     addLogEntry('Failed to open login page', 'error');
-  }
-}
-
-async function handleSelectLocation() {
-  // TODO: Implement folder selection
-  // Chrome extensions have limited file system access
-  // This will need to be implemented with downloads API
-  addLogEntry('Custom folder selection coming soon', 'warning');
-}
-
-async function handleSettingsChange() {
-  try {
-    const settings = {
-      downloadDelay: elements.downloadDelay.value * 1000,
-      metadataEmbedding: elements.embedMetadata.checked,
-      artworkEmbedding: elements.embedArtwork.checked
-    };
-    
-    await chrome.storage.local.set(settings);
-    addLogEntry('Settings saved');
-  } catch (error) {
-    addLogEntry('Failed to save settings', 'error');
   }
 }
 

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -122,37 +122,18 @@ describe('Popup UI', () => {
       const startBtn = document.querySelector('#startBtn');
       const pauseBtn = document.querySelector('#pauseBtn');
       const stopBtn = document.querySelector('#stopBtn');
-      
+
       expect(controlsSection).toBeTruthy();
       expect(startBtn).toBeTruthy();
       expect(pauseBtn).toBeTruthy();
       expect(stopBtn).toBeTruthy();
-      
+
       // Check initial states
       expect(startBtn.disabled).toBe(true);
       expect(pauseBtn.style.display).toBe('none');
       expect(stopBtn.style.display).toBe('none');
     });
-    
-    test('should have settings section', () => {
-      const settingsSection = document.querySelector('.settings-section');
-      const downloadLocation = document.querySelector('#downloadLocation');
-      const downloadDelay = document.querySelector('#downloadDelay');
-      const embedMetadata = document.querySelector('#embedMetadata');
-      const embedArtwork = document.querySelector('#embedArtwork');
-      
-      expect(settingsSection).toBeTruthy();
-      expect(downloadLocation).toBeTruthy();
-      expect(downloadDelay).toBeTruthy();
-      expect(embedMetadata).toBeTruthy();
-      expect(embedArtwork).toBeTruthy();
-      
-      // Check default values
-      expect(downloadDelay.value).toBe('2');
-      expect(embedMetadata.checked).toBe(true);
-      expect(embedArtwork.checked).toBe(true);
-    });
-    
+
     test('should have activity log section', () => {
       const logSection = document.querySelector('.log-section');
       const logContent = document.querySelector('#logContent');
@@ -174,27 +155,28 @@ describe('Popup UI', () => {
   });
   
   describe('Accessibility', () => {
-    test('should have proper label associations', () => {
-      const downloadLocationLabel = document.querySelector('label[for="downloadLocation"]');
-      const downloadDelayLabel = document.querySelector('label[for="downloadDelay"]');
-      
-      expect(downloadLocationLabel).toBeTruthy();
-      expect(downloadDelayLabel).toBeTruthy();
-    });
-    
     test('should have semantic HTML structure', () => {
       const header = document.querySelector('header');
       const sections = document.querySelectorAll('section');
       const footer = document.querySelector('footer');
-      
+
       expect(header).toBeTruthy();
       expect(sections.length).toBeGreaterThan(0);
       expect(footer).toBeTruthy();
     });
-    
+
+    test('should expose activity log summary for accessibility', () => {
+      const logDetails = document.querySelector('.log-section details');
+      const logSummary = document.querySelector('.log-section summary');
+
+      expect(logDetails).toBeTruthy();
+      expect(logSummary).toBeTruthy();
+      expect(logSummary.textContent).toContain('Activity Log');
+    });
+
     test('should have proper button types', () => {
       const buttons = document.querySelectorAll('button');
-      
+
       buttons.forEach(button => {
         // All buttons should have type="button" or be submit buttons
         const type = button.getAttribute('type');
@@ -202,26 +184,23 @@ describe('Popup UI', () => {
       });
     });
   });
-  
-  describe('Form Elements', () => {
-    test('should have proper input types and attributes', () => {
-      const downloadLocation = document.querySelector('#downloadLocation');
-      const downloadDelay = document.querySelector('#downloadDelay');
-      
-      expect(downloadLocation.type).toBe('text');
-      expect(downloadLocation.readOnly).toBe(true);
-      
-      expect(downloadDelay.type).toBe('number');
-      expect(downloadDelay.min).toBe('1');
-      expect(downloadDelay.max).toBe('60');
+
+  describe('Simplified Layout', () => {
+    test('should not include deprecated settings elements', () => {
+      expect(document.querySelector('.settings-section')).toBeNull();
+      expect(document.querySelector('#downloadDelay')).toBeNull();
+      expect(document.querySelector('#embedMetadata')).toBeNull();
+      expect(document.querySelector('#embedArtwork')).toBeNull();
     });
-    
-    test('should have checkboxes for boolean settings', () => {
-      const embedMetadata = document.querySelector('#embedMetadata');
-      const embedArtwork = document.querySelector('#embedArtwork');
-      
-      expect(embedMetadata.type).toBe('checkbox');
-      expect(embedArtwork.type).toBe('checkbox');
+
+    test('should display log controls within details element', () => {
+      const logDetails = document.querySelector('.log-section details');
+      const logContent = document.querySelector('.log-section .log-content');
+      const clearLogBtn = document.querySelector('#clearLogBtn');
+
+      expect(logDetails).toBeTruthy();
+      expect(logContent).toBeTruthy();
+      expect(clearLogBtn).toBeTruthy();
     });
   });
   


### PR DESCRIPTION
## Summary
- Removed all Settings UI elements from the popup interface
- Cleaned up unused CSS styles and JavaScript event handlers
- Simplified popup to focus on core download queue functionality

## Changes
- Removed settings section from popup.html (33 lines)
- Removed settings-related CSS styles from popup.css (60 lines)  
- Removed settings event handlers and related code from popup.js (40 lines)

## Test plan
- [ ] Verify popup still opens correctly
- [ ] Confirm download queue functionality remains intact
- [ ] Check that no console errors occur when opening popup
- [ ] Ensure popup UI looks clean without settings section

🤖 Generated with [Claude Code](https://claude.ai/code)