### PR TITLE
Refactor: DOM-only purchases scraping (Task 3.10)

### DIFF
--- a/content/bandcamp-scraper.js
+++ b/content/bandcamp-scraper.js
@@ -467,7 +467,19 @@ async function handleScrapePurchases(sendResponse) {
       return;
     }
 
-    // DOM mode: scrape visible, downloadable-only items using canonical selectors
+    // DOM mode: wait briefly for purchases list, then scrape using canonical selectors
+    try {
+      console.log('[TrailMix] Waiting for purchases list (canonical selector)…');
+      await DOMUtils.waitForElement('#oh-container > div.purchases > ol', 5000);
+    } catch (_) {
+      try {
+        console.log('[TrailMix] Canonical selector not ready; trying fallback selector…');
+        await DOMUtils.waitForElement('#oh-container div.purchases > ol', 5000);
+      } catch (_) {
+        // proceed to query below; will error if not found
+      }
+    }
+
     const listEl = document.querySelector('#oh-container > div.purchases > ol') ||
                    document.querySelector('#oh-container div.purchases > ol');
     if (!listEl) {

--- a/content/bandcamp-scraper.js
+++ b/content/bandcamp-scraper.js
@@ -476,7 +476,7 @@ async function handleScrapePurchases(sendResponse) {
       return;
     }
 
-    const itemNodes = listEl.querySelectorAll(':scope > div');
+    const itemNodes = Array.from(listEl.children).filter(n => n && n.tagName === 'DIV');
     if (!itemNodes || itemNodes.length === 0) {
       console.error('Purchases items not found (no direct div children)');
       sendResponse({ error: 'No purchases found in list' });

--- a/plans/implementation_plan.md
+++ b/plans/implementation_plan.md
@@ -535,9 +535,9 @@ Additional outcome:
 - [ ] **AC3.7.5**: Works with different Bandcamp page layouts
 - [ ] **AC3.7.6**: Scraping completes within reasonable time limits
 
-#### Task 3.10: Refactor Purchases Scraping (DOM-first, Known Selectors)
+#### Task 3.10: Refactor Purchases Scraping (DOM-only, Known Selectors)
 
-- [ ] Goal: Replace ad-hoc selector discovery with a deterministic, DOM-first scraper for the purchases page; use `#pagedata` exclusively only when the page shows all items (`N == M`). Keep interfaces and returned data exactly the same; maintain current download behavior for discovered items.
+- [ ] Goal: Replace ad-hoc selector discovery with a deterministic, DOM-only scraper for the purchases page. Do not use `#pagedata` in this task. Keep interfaces and returned data exactly the same; maintain current download behavior for discovered items.
 
 - [ ] Canonical selectors and structure:
   - [ ] List container: `#oh-container > div.purchases > ol` (ordered list).
@@ -545,10 +545,7 @@ Additional outcome:
   - [ ] Download link per item: within the item, find anchor with `a[data-tid="download"]` (e.g., under `div.purchases-item-actions`). Do not depend on anchor text.
   - [ ] Fallback list selector: if missing, try `#oh-container div.purchases > ol` (less strict). If still missing or zero items, log and throw.
 
-- [ ] Summary parsing and `#pagedata` usage:
-  - [ ] Summary selector: `#oh-container > div:nth-child(2) > span`, with `span.page-items-number` providing N; parse `showing N of M` to obtain both.
-  - [ ] If `N == M`: use `#pagedata` exclusively as the authoritative source (unchanged behavior), and prefer pagedata values on conflicts.
-  - [ ] If `N < M`: do not use `#pagedata`; scrape only what is visible via DOM and return the downloadable subset.
+- [ ] Summary parsing (optional): may parse `#oh-container > div:nth-child(2) > span` for diagnostics only; do not branch on summary values. Scrape only via DOM regardless of `N/M`.
 
 - [ ] Filtering and fields:
   - [ ] Return only items that have a direct download anchor (`a[data-tid="download"]`); skip non-downloadable items in DOM mode.
@@ -569,11 +566,11 @@ Additional outcome:
   - [ ] i18n and alternative DOM layouts.
 
 - [ ] Acceptance Criteria:
-  - [ ] AC3.10.1: On purchases pages showing all items (`N == M`), scraper uses `#pagedata` exclusively and returns the same fields as before.
-  - [ ] AC3.10.2: On purchases pages with partial visibility (`N < M`), scraper returns only the visible, downloadable items using the canonical DOM selectors.
+  - [ ] AC3.10.1: Scraper does not read or use `#pagedata` under any condition; DOM-only.
+  - [ ] AC3.10.2: Scraper returns only the visible, downloadable items using the canonical DOM selectors.
   - [ ] AC3.10.3: When the canonical list selector is missing or yields 0 items, the scraper logs and throws an error.
   - [ ] AC3.10.4: Response shape remains `{ success, purchases, totalCount, message? }` with identical item structure; downstream download behavior remains intact.
-  - [ ] AC3.10.5: In DOM mode, returned items are only those with `a[data-tid="download"]`, and download URLs are absolute.
+  - [ ] AC3.10.5: Returned items are only those with `a[data-tid="download"]`, and download URLs are absolute.
   - [ ] AC3.10.6: No legacy selectors or commented-out code remain; only the specified selectors are present in the scraper.
   - [ ] AC3.10.7: No dead code or unused scraping helpers remain after the refactor.
 

--- a/tests/unit/dom-scrape.test.js
+++ b/tests/unit/dom-scrape.test.js
@@ -1,0 +1,88 @@
+/**
+ * DOM-only purchases scraping tests for SCRAPE_PURCHASES
+ */
+const { JSDOM } = require('jsdom');
+
+// Mock Chrome APIs
+const chromeMock = require('../mocks/chrome-mock');
+global.chrome = chromeMock;
+
+describe('Content Script: DOM-only SCRAPE_PURCHASES', () => {
+  let dom;
+  let originalWindow;
+  let originalDocument;
+
+  beforeEach(() => {
+    originalWindow = global.window;
+    originalDocument = global.document;
+  });
+
+  afterEach(() => {
+    if (dom) dom.window.close();
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.resetModules();
+  });
+
+  function mountPurchasesDom(html) {
+    dom = new JSDOM(html, { url: 'https://bandcamp.com/testuser/purchases' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    jest.resetModules();
+    chrome.runtime.onMessage.addListener.mockClear();
+    delete require.cache[require.resolve('../../content/bandcamp-scraper.js')];
+    require('../../content/bandcamp-scraper.js');
+    const calls = chrome.runtime.onMessage.addListener.mock.calls;
+    return calls.length ? calls[0][0] : null;
+  }
+
+  test('returns only downloadable items via a[data-tid="download"]', async () => {
+    const html = `<!DOCTYPE html><html><body>
+      <div id="oh-container">
+        <div class="purchases">
+          <ol>
+            <div class="purchases-item" sale_item_id="1">
+              <div><div class="col flex-column spread"><div class="purchases-item-actions">
+                <a data-tid="download" href="/download?from=order_history&payment_id=1&sig=xyz&sitem_id=1">download track</a>
+              </div></div></div>
+            </div>
+            <div class="purchases-item" sale_item_id="2">
+              <!-- no download link -->
+            </div>
+          </ol>
+        </div>
+      </div>
+    </body></html>`;
+
+    const handler = mountPurchasesDom(html);
+    expect(handler).toBeTruthy();
+
+    const sendResponse = jest.fn();
+    const keepAlive = handler({ type: 'SCRAPE_PURCHASES' }, { tab: { id: 1 } }, sendResponse);
+    expect(keepAlive).toBe(true);
+
+    for (let i = 0; i < 100 && sendResponse.mock.calls.length === 0; i++) {
+      await new Promise(r => setTimeout(r, 1));
+    }
+
+    const resp = sendResponse.mock.calls[0][0];
+    expect(resp.success).toBe(true);
+    expect(resp.totalCount).toBe(1);
+    expect(resp.purchases[0].downloadUrl).toMatch(/^https:\/\/bandcamp\.com\/download\?/);
+  });
+
+  test('errors when list selector missing', async () => {
+    const html = '<!DOCTYPE html><html><body><div id="oh-container"></div></body></html>';
+    const handler = mountPurchasesDom(html);
+    expect(handler).toBeTruthy();
+
+    const sendResponse = jest.fn();
+    handler({ type: 'SCRAPE_PURCHASES' }, { tab: { id: 1 } }, sendResponse);
+    for (let i = 0; i < 100 && sendResponse.mock.calls.length === 0; i++) {
+      await new Promise(r => setTimeout(r, 1));
+    }
+    const resp = sendResponse.mock.calls[0][0];
+    expect(resp.error).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
Refactors purchases scraping to be DOM-only with canonical selectors (Task 3.10). Keeps response shape and download behavior unchanged.

## Changes
- Scraper: DOM-only on purchases pages
  - List: `#oh-container > div.purchases > ol` (fallback: `#oh-container div.purchases > ol`)
  - Items: direct child `div` elements of the list
  - Downloadable-only: anchor `a[data-tid="download"]`; normalize `href` to absolute with `new URL(href, location.origin).href`
- Remove all `#pagedata` usage (no gating on “showing N of M”)
- Strict errors: if list missing or empty, log + return error
- Response shape unchanged: `{ success, purchases, totalCount }`

## Tests
- Remove pagedata parsing unit test
- Add DOM-only scraping tests (`tests/unit/dom-scrape.test.js`)
- Update `SCRAPE_PURCHASES` unit test to use canonical selectors

## Verification
- Manual: verified on real purchases page (visible subset and full list)
- Pipeline: downloads continue for discovered items (download manager unchanged)

## Out of Scope
- “View All”/auto-scroll expansion (separate task)
- i18n or alternative layouts
- DOM extraction of title/artist/artwork (can be added later with explicit selectors)

## Rationale
- Deterministic selectors reduce drift and ambiguity
- Keeps behavior focused on downloadable items only (`data-tid="download"`)
