### PR TITLE
Revert CSP and warning button contrast changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+    "extension_pages": "script-src 'self'; object-src 'self';"
   }
 }

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -222,7 +222,7 @@ body {
 
 .btn-warning {
   background-color: var(--warning);
-  color: var(--dark-text);
+  color: var(--white);
 }
 
 .btn-warning:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
This PR reverts two specific changes that were included in PR #26:

1. **Remove Google Fonts from CSP policy** - Reverts the `manifest.json` changes that added `style-src` and `font-src` directives for Google Fonts
2. **Revert warning button text color** - Changes warning button text color back to white from dark text

## Changes
- `manifest.json`: Remove Google Fonts CSP directives
- `sidepanel/sidepanel.css`: Change `.btn-warning` color from `var(--dark-text)` back to `var(--white)`

## Context
These changes were part of the squashed commit `2177628` from PR #26, but need to be backed out while preserving all other changes from that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)