### PR TITLE
UI Tweaks: Improve not-logged-in and download progress states

### DIFF
--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -109,34 +109,27 @@ body {
 /* Progress Section */
 .progress-section {
   margin-bottom: 16px;
-  padding: 12px;
-  background-color: var(--white);
-  border-radius: 16px;
-  border: 1px solid var(--lavender-border);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .progress-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin-bottom: 12px;
 }
 
 .progress-header h3 {
   font-size: 14px;
-  font-weight: 600;
-  text-transform: uppercase;
+  font-weight: 400;
+  color: var(--dark-text);
 }
 
 .progress-stats {
   font-size: 12px;
   color: var(--text-secondary);
+  margin-top: 8px;
 }
 
 .progress-bar-container {
   position: relative;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .progress-bar {
@@ -154,13 +147,7 @@ body {
 }
 
 .progress-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--dark-text);
+  display: none;
 }
 
 .current-item {
@@ -185,6 +172,11 @@ body {
 .control-buttons {
   display: flex;
   gap: 8px;
+}
+
+/* Hide Start Download button when progress section is visible */
+.progress-section:not([style*="display: none"]) ~ .controls-section #startBtn {
+  display: none !important;
 }
 
 /* Buttons */

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -174,8 +174,8 @@ body {
   gap: 8px;
 }
 
-/* Hide Start Download button when progress section is visible */
-.progress-section:not([style*="display: none"]) ~ .controls-section #startBtn {
+/* Hide Start Download button when progress section is active */
+.progress-section.active ~ .controls-section #startBtn {
   display: none !important;
 }
 

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -79,7 +79,7 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
 .status-indicator {
@@ -91,6 +91,10 @@ body {
 
 .status-indicator.connected {
   background-color: var(--success);
+}
+
+.status-indicator.not-logged-in {
+  background-color: var(--primary-pink);
 }
 
 .status-indicator.error {

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -174,9 +174,18 @@ body {
   gap: 8px;
 }
 
+/* Start Download button visibility control */
+#startBtn {
+  display: none; /* Hidden by default */
+}
+
+#startBtn.visible {
+  display: inline-block;
+}
+
 /* Hide Start Download button when progress section is active */
 .progress-section.active ~ .controls-section #startBtn {
-  display: none !important;
+  display: none;
 }
 
 /* Buttons */

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -30,9 +30,6 @@
     <section class="progress-section" id="progressSection" style="display: none;">
       <div class="progress-header">
         <h3>Download Progress</h3>
-        <div class="progress-stats">
-          <span id="progressStats">0 of 0 albums</span>
-        </div>
       </div>
 
       <div class="progress-bar-container">
@@ -42,8 +39,12 @@
         <div class="progress-text" id="progressText">0%</div>
       </div>
 
+      <div class="progress-stats">
+        <span id="progressStats">0 of 0 albums</span>
+      </div>
+
       <div class="current-item" id="currentItem">
-        <div class="current-album">Ready to start</div>
+        <div class="current-album"></div>
         <div class="current-track"></div>
       </div>
     </section>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -84,6 +84,7 @@ async function loadInitialState() {
         elements.progressSection.classList.add('active');
         elements.pauseBtn.style.display = 'inline-block';
         elements.stopBtn.style.display = 'inline-block';
+        updateStartButtonVisibility(true, true); // authenticated=true, downloadActive=true
 
         // Update progress display
         if (state.total > 0) {
@@ -221,6 +222,7 @@ async function handleStartDownload() {
       elements.progressSection.classList.add('active');
       elements.pauseBtn.style.display = 'inline-block';
       elements.stopBtn.style.display = 'inline-block';
+      updateStartButtonVisibility(true, true); // authenticated=true, downloadActive=true
 
       elements.progressStats.textContent = formatProgressStats(0, 0, response.totalPurchases || 0);
       addLogEntry('Download started', 'success');
@@ -274,7 +276,8 @@ async function handleStopDownload() {
       elements.progressSection.classList.remove('active');
       elements.pauseBtn.style.display = 'none';
       elements.stopBtn.style.display = 'none';
-      
+      updateStartButtonVisibility(true, false); // authenticated=true, downloadActive=false
+
       addLogEntry('Download stopped', 'warning');
     }
   } catch (error) {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -127,6 +127,7 @@ async function checkAuthenticationStatus() {
     
     if (response.isAuthenticated) {
       updateAuthStatus('connected', 'Connected to Bandcamp');
+      elements.startBtn.style.display = 'inline-block';
       elements.startBtn.disabled = false;
       elements.loginBtn.style.display = 'none';
       addLogEntry('Authentication verified');
@@ -136,8 +137,9 @@ async function checkAuthenticationStatus() {
         addLogEntry(`Found ${response.userInfo.collectionCount} items in collection`);
       }
     } else {
-      updateAuthStatus('error', 'Not logged in to Bandcamp');
+      updateAuthStatus('not-logged-in', 'Not logged in to Bandcamp');
       elements.loginBtn.style.display = 'inline-block';
+      elements.startBtn.style.display = 'none';
       elements.startBtn.disabled = true;
       addLogEntry('Authentication required - please log in to Bandcamp', 'warning');
     }

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -90,7 +90,7 @@ async function loadInitialState() {
           const percentage = Math.round((state.completed / state.total) * 100);
           elements.progressFill.style.width = `${percentage}%`;
           elements.progressText.textContent = `${percentage}%`;
-          elements.progressStats.textContent = `${percentage}% (${state.completed} of ${state.total} albums)`;
+          elements.progressStats.textContent = formatProgressStats(percentage, state.completed, state.total);
         }
 
         // Set correct button state
@@ -162,6 +162,14 @@ function updateStartButtonVisibility(isAuthenticated, isDownloadActive) {
   }
 }
 
+function formatProgressStats(percentage, completed, total, active) {
+  let stats = `${percentage}% (${completed} of ${total} albums)`;
+  if (active !== undefined && active > 0) {
+    stats += ` (${active} active)`;
+  }
+  return stats;
+}
+
 // Event handlers
 async function handleStartDownload() {
   try {
@@ -214,7 +222,7 @@ async function handleStartDownload() {
       elements.pauseBtn.style.display = 'inline-block';
       elements.stopBtn.style.display = 'inline-block';
 
-      elements.progressStats.textContent = `0% (0 of ${response.totalPurchases || 0} albums)`;
+      elements.progressStats.textContent = formatProgressStats(0, 0, response.totalPurchases || 0);
       addLogEntry('Download started', 'success');
     } else if (response && response.status === 'failed') {
       addLogEntry('Failed to start download: ' + (response.error || 'Unknown error'), 'error');
@@ -322,12 +330,8 @@ function updateProgress(stats) {
     elements.progressFill.style.width = `${percentage}%`;
     elements.progressText.textContent = `${percentage}%`;
 
-    // Show active downloads count
-    if (stats.active !== undefined && stats.active > 0) {
-      elements.progressStats.textContent = `${percentage}% (${stats.completed} of ${stats.total} albums) (${stats.active} active)`;
-    } else {
-      elements.progressStats.textContent = `${percentage}% (${stats.completed} of ${stats.total} albums)`;
-    }
+    // Update progress stats text
+    elements.progressStats.textContent = formatProgressStats(percentage, stats.completed, stats.total, stats.active);
 
     if (stats.currentAlbum) {
       elements.currentItem.querySelector('.current-album').textContent = stats.currentAlbum;

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -81,7 +81,7 @@ async function loadInitialState() {
       if (state.isActive || state.isPaused || state.queueSize > 0) {
         // Show progress section since we have an active/paused queue
         elements.progressSection.style.display = 'block';
-        elements.startBtn.style.display = 'none';
+        elements.progressSection.classList.add('active');
         elements.pauseBtn.style.display = 'inline-block';
         elements.stopBtn.style.display = 'inline-block';
 
@@ -202,7 +202,7 @@ async function handleStartDownload() {
 
     if (response && response.status === 'started') {
       elements.progressSection.style.display = 'block';
-      elements.startBtn.style.display = 'none';
+      elements.progressSection.classList.add('active');
       elements.pauseBtn.style.display = 'inline-block';
       elements.stopBtn.style.display = 'inline-block';
 
@@ -255,7 +255,7 @@ async function handleStopDownload() {
     
     if (response.status === 'stopped') {
       elements.progressSection.style.display = 'none';
-      elements.startBtn.style.display = 'inline-block';
+      elements.progressSection.classList.remove('active');
       elements.pauseBtn.style.display = 'none';
       elements.stopBtn.style.display = 'none';
       

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -127,7 +127,7 @@ async function checkAuthenticationStatus() {
     
     if (response.isAuthenticated) {
       updateAuthStatus('connected', 'Connected to Bandcamp');
-      elements.startBtn.style.display = 'inline-block';
+      updateStartButtonVisibility(true, false);
       elements.startBtn.disabled = false;
       elements.loginBtn.style.display = 'none';
       addLogEntry('Authentication verified');
@@ -139,7 +139,7 @@ async function checkAuthenticationStatus() {
     } else {
       updateAuthStatus('not-logged-in', 'Not logged in to Bandcamp');
       elements.loginBtn.style.display = 'inline-block';
-      elements.startBtn.style.display = 'none';
+      updateStartButtonVisibility(false, false);
       elements.startBtn.disabled = true;
       addLogEntry('Authentication required - please log in to Bandcamp', 'warning');
     }
@@ -152,6 +152,14 @@ async function checkAuthenticationStatus() {
 function updateAuthStatus(status, message) {
   elements.statusText.textContent = message;
   elements.statusIndicator.className = `status-indicator ${status}`;
+}
+
+function updateStartButtonVisibility(isAuthenticated, isDownloadActive) {
+  if (isAuthenticated && !isDownloadActive) {
+    elements.startBtn.classList.add('visible');
+  } else {
+    elements.startBtn.classList.remove('visible');
+  }
 }
 
 // Event handlers

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -90,7 +90,7 @@ async function loadInitialState() {
           const percentage = Math.round((state.completed / state.total) * 100);
           elements.progressFill.style.width = `${percentage}%`;
           elements.progressText.textContent = `${percentage}%`;
-          elements.progressStats.textContent = `${state.completed} of ${state.total} albums`;
+          elements.progressStats.textContent = `${percentage}% (${state.completed} of ${state.total} albums)`;
         }
 
         // Set correct button state
@@ -206,7 +206,7 @@ async function handleStartDownload() {
       elements.pauseBtn.style.display = 'inline-block';
       elements.stopBtn.style.display = 'inline-block';
 
-      elements.progressStats.textContent = `0 of ${response.totalPurchases || 0} albums`;
+      elements.progressStats.textContent = `0% (0 of ${response.totalPurchases || 0} albums)`;
       addLogEntry('Download started', 'success');
     } else if (response && response.status === 'failed') {
       addLogEntry('Failed to start download: ' + (response.error || 'Unknown error'), 'error');
@@ -313,11 +313,12 @@ function updateProgress(stats) {
     const percentage = Math.round((stats.completed / stats.total) * 100);
     elements.progressFill.style.width = `${percentage}%`;
     elements.progressText.textContent = `${percentage}%`;
-    elements.progressStats.textContent = `${stats.completed} of ${stats.total} albums`;
 
     // Show active downloads count
     if (stats.active !== undefined && stats.active > 0) {
-      elements.progressStats.textContent += ` (${stats.active} active)`;
+      elements.progressStats.textContent = `${percentage}% (${stats.completed} of ${stats.total} albums) (${stats.active} active)`;
+    } else {
+      elements.progressStats.textContent = `${percentage}% (${stats.completed} of ${stats.total} albums)`;
     }
 
     if (stats.currentAlbum) {


### PR DESCRIPTION
## Summary
Small, tactical UI improvements to the side panel:

### Not-logged-in State
- Hide Start Download button when user is not logged in
- Change status indicator to pink (#FF4EB6) instead of red error color
- Increase spacing between status text and login button (8px → 12px)

### Download Progress Section
- Remove card styling (white background, border, shadow, padding) for cleaner look
- Simplify "DOWNLOAD PROGRESS" heading to "Download Progress"
- Move progress stats below progress bar
- Hide percentage overlay on progress bar
- Combine percentage with album count: "4% (1 of 24 albums)"
- Remove "Ready to start" placeholder text
- Ensure Start Download button stays hidden during active downloads

## Files Changed
- `sidepanel/sidepanel.css` - Updated styles
- `sidepanel/sidepanel.html` - Restructured progress section layout
- `sidepanel/sidepanel.js` - Updated display logic and progress text formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)