### PR TITLE
feat: Replace purchases page scraping with collection API

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -770,6 +770,11 @@ async function discoverCollectionItems() {
       }
 
       console.log(`[TrailMix] Page ${pageNum}: got ${data.items ? data.items.length : 0} items, more_available=${moreAvailable}`);
+
+      // Small delay between pages to avoid rate limiting
+      if (moreAvailable) {
+        await new Promise(r => setTimeout(r, 100));
+      }
     }
 
     console.log(`[TrailMix] Collection discovery complete: ${allItems.length} items, ${Object.keys(allRedownloadUrls).length} download URLs`);
@@ -777,6 +782,8 @@ async function discoverCollectionItems() {
     // Step 4: Join items with their download URLs
     const purchases = [];
     for (const item of allItems) {
+      // redownload_urls are keyed by sale_item_type prefix + sale_item_id
+      // Known types: p=purchase, s=subscription, i=invitation, r=reseller
       const saleItemKey = (item.sale_item_type || 'p') + item.sale_item_id;
       const downloadUrl = allRedownloadUrls[saleItemKey];
 

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -540,8 +540,8 @@ async function handleStartDownload(data, sendResponse) {
       // Accept nested payload shape as well
       purchases = data.data.purchases;
     } else {
-      // Fallback: discover purchases
-      const discoveryResponse = await discoverPurchases();
+      // Fallback: discover collection items via API
+      const discoveryResponse = await discoverCollectionItems();
       if (!discoveryResponse.success) {
         sendResponse({ status: 'failed', error: discoveryResponse.error });
         return;
@@ -687,7 +687,124 @@ async function handleDiscoverPurchases(sendResponse) {
   }
 }
 
-// Discover purchases by communicating with content script
+// Discover collection items via Bandcamp's collection API
+// This replaces the old DOM-scraping approach with direct API calls
+async function discoverCollectionItems() {
+  try {
+    // Step 1: Get all bandcamp.com cookies for authenticated API requests
+    const cookies = await chrome.cookies.getAll({ domain: '.bandcamp.com' });
+    if (!cookies || cookies.length === 0) {
+      return { success: false, error: 'Not logged in to Bandcamp (no cookies found)' };
+    }
+    const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ');
+
+    // Step 2: Get fan_id from collection_summary API
+    const summaryResponse = await fetch('https://bandcamp.com/api/fan/2/collection_summary', {
+      method: 'GET',
+      headers: { 'Cookie': cookieHeader }
+    });
+
+    if (!summaryResponse.ok) {
+      return { success: false, error: `Failed to get fan info (HTTP ${summaryResponse.status})` };
+    }
+
+    const summaryData = await summaryResponse.json();
+    const fanId = summaryData.fan_id;
+
+    if (!fanId) {
+      return { success: false, error: 'Not logged in to Bandcamp (no fan_id in API response)' };
+    }
+
+    console.log(`[TrailMix] Starting collection discovery for fan_id=${fanId}`);
+
+    // Step 3: Paginate through the collection API
+    let allItems = [];
+    let allRedownloadUrls = {};
+    let olderThanToken = '9999999999::a::';
+    let moreAvailable = true;
+    let pageNum = 0;
+
+    while (moreAvailable) {
+      pageNum++;
+
+      // Check if discovery was cancelled
+      if (discoveryCancelled) {
+        console.log('[TrailMix] Collection discovery cancelled during pagination');
+        return { success: false, error: 'Discovery cancelled' };
+      }
+
+      console.log(`[TrailMix] Fetching collection page ${pageNum} (token: ${olderThanToken})`);
+
+      const response = await fetch('https://bandcamp.com/api/fancollection/1/collection_items', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cookie': cookieHeader
+        },
+        body: JSON.stringify({
+          fan_id: fanId,
+          older_than_token: olderThanToken,
+          count: 100
+        })
+      });
+
+      if (!response.ok) {
+        return { success: false, error: `Collection API returned HTTP ${response.status}` };
+      }
+
+      const data = await response.json();
+
+      if (data.items && Array.isArray(data.items)) {
+        allItems = allItems.concat(data.items);
+      }
+
+      if (data.redownload_urls && typeof data.redownload_urls === 'object') {
+        Object.assign(allRedownloadUrls, data.redownload_urls);
+      }
+
+      moreAvailable = !!data.more_available;
+      if (moreAvailable && data.last_token) {
+        olderThanToken = data.last_token;
+      } else {
+        moreAvailable = false;
+      }
+
+      console.log(`[TrailMix] Page ${pageNum}: got ${data.items ? data.items.length : 0} items, more_available=${moreAvailable}`);
+    }
+
+    console.log(`[TrailMix] Collection discovery complete: ${allItems.length} items, ${Object.keys(allRedownloadUrls).length} download URLs`);
+
+    // Step 4: Join items with their download URLs
+    const purchases = [];
+    for (const item of allItems) {
+      const saleItemKey = (item.sale_item_type || 'p') + item.sale_item_id;
+      const downloadUrl = allRedownloadUrls[saleItemKey];
+
+      if (!downloadUrl) {
+        console.log(`[TrailMix] Skipping item "${item.item_title}" by ${item.band_name} - no download URL`);
+        continue;
+      }
+
+      purchases.push({
+        title: item.item_title || '',
+        artist: item.band_name || '',
+        downloadUrl: downloadUrl,
+        url: item.item_url || '',
+        artworkUrl: '',
+        purchaseDate: item.purchased || '',
+        itemType: item.tralbum_type || ''
+      });
+    }
+
+    return { success: true, purchases, totalCount: purchases.length };
+
+  } catch (error) {
+    console.error('[TrailMix] Error in discoverCollectionItems:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+// Legacy: Discover purchases by communicating with content script (replaced by discoverCollectionItems)
 async function discoverPurchases() {
   try {
     // Find or create a Bandcamp tab
@@ -798,12 +915,12 @@ async function handleDiscoverAndStart(sendResponse) {
     // Reset cancellation flag at the start of discovery
     discoveryCancelled = false;
 
-    const discoveryResponse = await discoverPurchases();
+    const discoveryResponse = await discoverCollectionItems();
 
     // Check if discovery was cancelled during the process
     if (discoveryCancelled) {
       console.log('Discovery was cancelled, aborting DISCOVER_AND_START');
-      broadcastLogMessage('Purchase discovery cancelled', 'warning');
+      broadcastLogMessage('Collection discovery cancelled', 'warning');
       sendResponse({ status: 'cancelled' });
       return;
     }

--- a/content/bandcamp-scraper.js
+++ b/content/bandcamp-scraper.js
@@ -859,6 +859,19 @@ async function handleCheckDownloadReady(sendResponse) {
           preparing: true
         });
       } else {
+        // Check if the download has expired
+        const pageText = document.body ? (document.body.textContent || '') : '';
+        if (pageText.includes('Download expired')) {
+          console.log('Download expired detected');
+          sendResponse({
+            ready: false,
+            expired: true,
+            error: 'Download expired',
+            metadata: { artist, title }
+          });
+          return;
+        }
+
         // Look for any visible download link with different selectors
         const alternativeSelectors = [
           'a[data-bind*="downloadUrl"]',

--- a/lib/download-manager.js
+++ b/lib/download-manager.js
@@ -128,6 +128,9 @@ class DownloadManager {
 
           // Step 3: Extract and initiate download
           await this.initiateDownload(response.url);
+        } else if (response && response.expired) {
+          // Download link has expired - fail immediately, no point retrying
+          throw new Error('Download expired - re-download link needed');
         } else if (checkCount >= maxChecks) {
           // Timeout
           throw new Error('Download preparation timeout');

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -384,6 +384,22 @@ function updateProgress(stats) {
       elements.currentItem.querySelector('.current-track').textContent = stats.currentTrack;
     }
 
+    // Check if downloads are complete (queue empty, not active, not paused)
+    if (!stats.isActive && !stats.isPaused && stats.active === 0) {
+      // All done — reset UI to start state
+      elements.pauseBtn.style.display = 'none';
+      elements.stopBtn.style.display = 'none';
+      updateStartButtonVisibility(true, false);
+
+      const failed = stats.failed || 0;
+      if (failed > 0) {
+        addLogEntry(`Downloads complete: ${stats.completed} succeeded, ${failed} failed`, 'warning');
+      } else {
+        addLogEntry(`All ${stats.completed} downloads complete!`, 'success');
+      }
+      return;
+    }
+
     // Update pause button state based on queue status
     if (typeof stats.isPaused === 'boolean' && elements.pauseBtn) {
       if (stats.isPaused) {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -209,6 +209,9 @@ async function handleStartDownload() {
     showDiscoveryView();
     addLogEntry('Discovering purchases...');
 
+    // Reset completion guard for new session
+    completionLogged = false;
+
     // Single-step flow: discovery and start handled entirely by background
     const response = await sendMessageToBackground({ type: 'DISCOVER_AND_START' });
     console.log('DISCOVER_AND_START response:', response);
@@ -346,6 +349,9 @@ function sendMessageToBackground(message) {
 let lastLogMessage = null;
 let lastLogTimestamp = 0;
 
+// Guard to prevent duplicate completion messages
+let completionLogged = false;
+
 function addLogEntry(message, type = 'info') {
   const now = Date.now();
 
@@ -391,11 +397,14 @@ function updateProgress(stats) {
       elements.stopBtn.style.display = 'none';
       updateStartButtonVisibility(true, false);
 
-      const failed = stats.failed || 0;
-      if (failed > 0) {
-        addLogEntry(`Downloads complete: ${stats.completed} succeeded, ${failed} failed`, 'warning');
-      } else {
-        addLogEntry(`All ${stats.completed} downloads complete!`, 'success');
+      if (!completionLogged) {
+        completionLogged = true;
+        const failed = stats.failed || 0;
+        if (failed > 0) {
+          addLogEntry(`Downloads complete: ${stats.completed} succeeded, ${failed} failed`, 'warning');
+        } else {
+          addLogEntry(`All ${stats.completed} downloads complete!`, 'success');
+        }
       }
       return;
     }


### PR DESCRIPTION
## Summary
- Replaces DOM-scraping of the `/purchases` page with direct calls to Bandcamp's `/api/fancollection/1/collection_items` API for discovering downloadable items
- The purchases page was not guaranteed to show all purchases; the collection API returns the complete collection reliably
- Detects expired download links and fails fast instead of retrying with invalid URLs
- Resets the side panel UI when all downloads complete, showing a success/fail summary

## Changes
- **`background/service-worker.js`** — New `discoverCollectionItems()` function that fetches `fan_id` via `collection_summary` API, paginates `collection_items` with session cookies, and maps `redownload_urls` using the correct `sale_item_type` prefix (`p`/`s`/`i`/`r`)
- **`content/bandcamp-scraper.js`** — `handleCheckDownloadReady()` now detects "Download expired" text and returns `{ expired: true }`
- **`lib/download-manager.js`** — Checks for `response.expired` and throws immediately instead of retrying
- **`sidepanel/sidepanel.js`** — `updateProgress()` detects `isActive: false` completion state, hides controls, and logs completion summary

## Test plan
- [ ] Load extension, log in to Bandcamp, click Start Download
- [ ] Verify console shows API calls to `collection_items` (not page navigation/DOM scraping)
- [ ] Verify all collection items are discovered (check log count matches collection size)
- [ ] Verify downloads proceed normally through the existing download page flow
- [ ] Verify expired downloads fail fast with clear error message
- [ ] Verify UI resets to start state after all downloads complete
- [ ] Run `npm test` — existing tests pass (301/350, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)