### PR TITLE
chore: Bump version to 1.2.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Trail Mix",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pack light. Bring your whole Bandcamp collection.",
   "permissions": [
     "downloads",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trail-mix",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Trail Mix - Chrome extension for bulk downloading Bandcamp purchases",
   "scripts": {
     "test": "jest",

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -12,7 +12,7 @@
     <!-- Header -->
     <header class="header">
       <h1 class="title">Trail Mix</h1>
-      <div class="version">v1.0.0</div>
+      <div class="version" id="version"></div>
     </header>
 
     <!-- Authentication Status -->

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -50,6 +50,9 @@ async function initializePopup() {
     clearLogBtn: document.getElementById('clearLogBtn')
   };
 
+  // Set version from manifest
+  document.getElementById('version').textContent = 'v' + chrome.runtime.getManifest().version;
+
   // Set up event listeners
   setupEventListeners();
 


### PR DESCRIPTION
## Summary
- Bump version to 1.2.0 in manifest.json and package.json
- Side panel version display now reads dynamically from `chrome.runtime.getManifest().version` instead of a hardcoded string (was stuck at v1.0.0)

## Test plan
- [ ] Reload extension, verify side panel shows `v1.2.0`
- [ ] Run `npm run package` to build submission bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)