### PR TITLE
fix: accurate progress bar for large collections (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ temp/
 # Chrome Web Store submission files (local only)
 STORE_LISTING.md
 SUBMISSION_CHECKLIST.md
+.gstack/

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1138,7 +1138,8 @@ function broadcastProgress() {
     isActive: downloadState.isActive,
     isPaused: downloadQueue.isPaused,
     queueSize: queueStats.total,
-    currentJob: currentDownloadJob ? currentDownloadJob.getStatusText() : null
+    currentJob: currentDownloadJob ? currentDownloadJob.getStatusText() : null,
+    currentJobPercent: currentDownloadJob?.progress?.percentComplete ?? 0
   };
 
   // Send to all extension views (popup, etc)

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1139,7 +1139,9 @@ function broadcastProgress() {
     isPaused: downloadQueue.isPaused,
     queueSize: queueStats.total,
     currentJob: currentDownloadJob ? currentDownloadJob.getStatusText() : null,
-    currentJobPercent: currentDownloadJob?.progress?.percentComplete ?? 0
+    currentJobPercent: currentDownloadJob && currentDownloadJob.status === 'downloading'
+      ? (currentDownloadJob.progress?.percentComplete ?? 0)
+      : 0
   };
 
   // Send to all extension views (popup, etc)

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -190,10 +190,11 @@ function formatFillWidth(percentage) {
 }
 
 // Keep displayed % in sync with a visibly non-empty bar: any real progress
-// shows as at least 1%.
+// shows as at least 1%, and never shows "100%" until the bar is actually full.
 function formatDisplayPercent(percentage) {
   if (percentage <= 0) return 0;
-  return Math.max(1, Math.round(percentage));
+  if (percentage >= 100) return 100;
+  return Math.max(1, Math.min(99, Math.round(percentage)));
 }
 
 function formatProgressStats(percentage, completed, total, active) {
@@ -459,3 +460,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     addLogEntry(message.message, message.logType);
   }
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    computeExactPercentage,
+    formatFillWidth,
+    formatDisplayPercent
+  };
+}

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -97,10 +97,11 @@ async function loadInitialState() {
 
         // Update progress display
         if (state.total > 0) {
-          const percentage = Math.round((state.completed / state.total) * 100);
-          elements.progressFill.style.width = `${percentage}%`;
-          elements.progressText.textContent = `${percentage}%`;
-          elements.progressStats.textContent = formatProgressStats(percentage, state.completed, state.total);
+          const exactPercentage = computeExactPercentage(state);
+          const displayPercentage = formatDisplayPercent(exactPercentage);
+          elements.progressFill.style.width = formatFillWidth(exactPercentage);
+          elements.progressText.textContent = `${displayPercentage}%`;
+          elements.progressStats.textContent = formatProgressStats(displayPercentage, state.completed, state.total);
         }
 
         // Set correct button state
@@ -169,6 +170,30 @@ function updateStartButtonVisibility(isAuthenticated, isDownloadActive) {
   } else {
     elements.startBtn.classList.remove('visible');
   }
+}
+
+function computeExactPercentage(stats) {
+  if (!stats || !stats.total) return 0;
+  const base = stats.completed / stats.total;
+  const inFlight = stats.active > 0 && typeof stats.currentJobPercent === 'number'
+    ? (stats.currentJobPercent / 100) / stats.total
+    : 0;
+  const combined = Math.min(1, base + inFlight);
+  return combined * 100;
+}
+
+// Rounded-corner container clips sub-10px fill to near-invisibility. Ensure
+// any nonzero progress renders with a visible minimum width.
+function formatFillWidth(percentage) {
+  if (percentage <= 0) return '0%';
+  return `max(10px, ${percentage.toFixed(2)}%)`;
+}
+
+// Keep displayed % in sync with a visibly non-empty bar: any real progress
+// shows as at least 1%.
+function formatDisplayPercent(percentage) {
+  if (percentage <= 0) return 0;
+  return Math.max(1, Math.round(percentage));
 }
 
 function formatProgressStats(percentage, completed, total, active) {
@@ -378,12 +403,13 @@ function addLogEntry(message, type = 'info') {
 // Update progress (will be called by background script)
 function updateProgress(stats) {
   if (stats.total > 0) {
-    const percentage = Math.round((stats.completed / stats.total) * 100);
-    elements.progressFill.style.width = `${percentage}%`;
-    elements.progressText.textContent = `${percentage}%`;
+    const exactPercentage = computeExactPercentage(stats);
+    const displayPercentage = formatDisplayPercent(exactPercentage);
+    elements.progressFill.style.width = formatFillWidth(exactPercentage);
+    elements.progressText.textContent = `${displayPercentage}%`;
 
     // Update progress stats text
-    elements.progressStats.textContent = formatProgressStats(percentage, stats.completed, stats.total, stats.active);
+    elements.progressStats.textContent = formatProgressStats(displayPercentage, stats.completed, stats.total, stats.active);
 
     if (stats.currentAlbum) {
       elements.currentItem.querySelector('.current-album').textContent = stats.currentAlbum;

--- a/tests/unit/sidepanel-progress.test.js
+++ b/tests/unit/sidepanel-progress.test.js
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for sidepanel progress-bar helpers: computeExactPercentage,
+ * formatFillWidth, formatDisplayPercent.
+ *
+ * Covers the fix for #50 — sub-percent bar resolution, minimum visible
+ * width, and text that stays in sync with the non-empty bar.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const chromeMock = require('../mocks/chrome-mock');
+
+describe('sidepanel progress helpers', () => {
+  let helpers;
+
+  beforeAll(() => {
+    const htmlPath = path.join(__dirname, '../../sidepanel/sidepanel.html');
+    const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+    const dom = new JSDOM(htmlContent, {
+      url: 'chrome-extension://test/sidepanel/sidepanel.html'
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.chrome = {
+      ...chromeMock,
+      tabs: {
+        ...chromeMock.tabs,
+        onUpdated: { addListener: jest.fn(), removeListener: jest.fn() }
+      }
+    };
+
+    jest.isolateModules(() => {
+      helpers = require('../../sidepanel/sidepanel.js');
+    });
+  });
+
+  describe('computeExactPercentage', () => {
+    test('returns 0 for empty/missing stats', () => {
+      expect(helpers.computeExactPercentage(null)).toBe(0);
+      expect(helpers.computeExactPercentage({})).toBe(0);
+      expect(helpers.computeExactPercentage({ total: 0, completed: 0 })).toBe(0);
+    });
+
+    test('returns completed/total*100 when no active job', () => {
+      const pct = helpers.computeExactPercentage({ completed: 1, total: 697, active: 0 });
+      expect(pct).toBeCloseTo(100 / 697, 6);
+    });
+
+    test('adds in-flight byte fraction when job is active', () => {
+      const pct = helpers.computeExactPercentage({
+        completed: 1, total: 697, active: 1, currentJobPercent: 50
+      });
+      // base 1/697 + partial 0.5/697 = 1.5/697
+      expect(pct).toBeCloseTo((1.5 / 697) * 100, 6);
+    });
+
+    test('skips in-flight when active is 0', () => {
+      const pct = helpers.computeExactPercentage({
+        completed: 1, total: 697, active: 0, currentJobPercent: 50
+      });
+      expect(pct).toBeCloseTo((1 / 697) * 100, 6);
+    });
+
+    test('skips in-flight when currentJobPercent is not a number', () => {
+      const pct = helpers.computeExactPercentage({
+        completed: 1, total: 697, active: 1
+      });
+      expect(pct).toBeCloseTo((1 / 697) * 100, 6);
+    });
+
+    test('caps at 100% when base+inFlight would exceed 1', () => {
+      const pct = helpers.computeExactPercentage({
+        completed: 697, total: 697, active: 1, currentJobPercent: 99
+      });
+      expect(pct).toBe(100);
+    });
+
+    test('handles restore-path stats without active/currentJobPercent', () => {
+      // loadInitialState passes the GET_EXTENSION_STATUS payload which omits
+      // both fields. Must fall back to base fraction without error.
+      const pct = helpers.computeExactPercentage({ completed: 6, total: 697 });
+      expect(pct).toBeCloseTo((6 / 697) * 100, 6);
+    });
+  });
+
+  describe('formatFillWidth', () => {
+    test('returns 0% for non-positive percentages', () => {
+      expect(helpers.formatFillWidth(0)).toBe('0%');
+      expect(helpers.formatFillWidth(-0.1)).toBe('0%');
+    });
+
+    test('clamps small nonzero percentages to a 10px minimum', () => {
+      expect(helpers.formatFillWidth(0.14)).toBe('max(10px, 0.14%)');
+      expect(helpers.formatFillWidth(1.5)).toBe('max(10px, 1.50%)');
+    });
+
+    test('uses the exact percentage at higher values', () => {
+      expect(helpers.formatFillWidth(50)).toBe('max(10px, 50.00%)');
+      expect(helpers.formatFillWidth(99.87)).toBe('max(10px, 99.87%)');
+    });
+
+    test('rounds to 2 decimals', () => {
+      expect(helpers.formatFillWidth(1 / 3)).toBe('max(10px, 0.33%)');
+    });
+  });
+
+  describe('formatDisplayPercent', () => {
+    test('returns 0 for zero/negative input', () => {
+      expect(helpers.formatDisplayPercent(0)).toBe(0);
+      expect(helpers.formatDisplayPercent(-1)).toBe(0);
+    });
+
+    test('floors any real progress to at least 1', () => {
+      expect(helpers.formatDisplayPercent(0.14)).toBe(1);
+      expect(helpers.formatDisplayPercent(0.49)).toBe(1);
+      expect(helpers.formatDisplayPercent(1.0)).toBe(1);
+    });
+
+    test('rounds normally in the mid range', () => {
+      expect(helpers.formatDisplayPercent(1.5)).toBe(2);
+      expect(helpers.formatDisplayPercent(50.49)).toBe(50);
+      expect(helpers.formatDisplayPercent(50.5)).toBe(51);
+    });
+
+    test('caps at 99 until percentage is exactly 100', () => {
+      expect(helpers.formatDisplayPercent(99.4)).toBe(99);
+      expect(helpers.formatDisplayPercent(99.5)).toBe(99);
+      expect(helpers.formatDisplayPercent(99.99)).toBe(99);
+    });
+
+    test('returns 100 only when progress is truly complete', () => {
+      expect(helpers.formatDisplayPercent(100)).toBe(100);
+      expect(helpers.formatDisplayPercent(100.5)).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Progress bar now advances smoothly (~0.14% per album) instead of jumping in 1% steps, so large collections no longer show the bar "frozen" at 1% or 2% for dozens of album completions.
- Includes byte-level in-flight progress of the active album so the bar also moves during multi-hundred-MB ZIP downloads.
- Clamps the fill to a visible 10px minimum for low single-digit percentages (the rounded container previously clipped the fill to an invisible sliver).
- Floors the displayed text to 1% whenever progress > 0 so the number stays in sync with the visibly non-empty bar.

Closes #50.

## Test plan
- [x] Verified live against a 697-album Bandcamp collection: bar advances smoothly from album 1, sub-percent width resolution confirmed via DOM snapshots (widths `0.14% → 0.86% → 1.43% → 2.58%` over albums 1–18).
- [x] Confirmed text/bar stay in sync (no more "bar visible / 0%" mismatch at low albums).
- [x] Caught the `(1 active)` indicator + in-flight byte fractional contribution mid-album.
- [ ] Reload the extension with a pre-existing paused queue and confirm the restore path renders the bar correctly.
- [ ] Manual check with a small (<20) collection to confirm nothing regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)