### PR TITLE
fix: show status text while resuming a paused download (#52)

### DIFF
--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -172,6 +172,13 @@ body {
   margin-top: 8px;
 }
 
+.progress-status {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-style: italic;
+  margin-top: 6px;
+}
+
 .progress-bar-container {
   position: relative;
   margin-bottom: 8px;

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -52,6 +52,8 @@
         <span id="progressStats">0 of 0 albums</span>
       </div>
 
+      <div class="progress-status" id="progressStatus" style="display: none;"></div>
+
       <div class="current-item" id="currentItem">
         <div class="current-album"></div>
         <div class="current-track"></div>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -41,6 +41,7 @@ async function initializePopup() {
     progressStats: document.getElementById('progressStats'),
     progressFill: document.getElementById('progressFill'),
     progressText: document.getElementById('progressText'),
+    progressStatus: document.getElementById('progressStatus'),
     currentItem: document.getElementById('currentItem'),
     controlsSection: document.querySelector('.controls-section'),
     startBtn: document.getElementById('startBtn'),
@@ -292,6 +293,12 @@ async function handlePauseDownload() {
 }
 
 async function handleResumeDownload() {
+  // Immediate feedback — the resume round-trip can take several seconds
+  // while the service worker wakes up and restores queue state.
+  elements.pauseBtn.textContent = 'Resuming...';
+  elements.pauseBtn.disabled = true;
+  showProgressStatus('Resuming downloads...');
+
   try {
     const response = await sendMessageToBackground({ type: 'START_DOWNLOAD' });
 
@@ -300,10 +307,29 @@ async function handleResumeDownload() {
       elements.pauseBtn.textContent = 'Pause';
       elements.pauseBtn.onclick = handlePauseDownload;
       addLogEntry('Download resumed', 'success');
+    } else {
+      // Unexpected response — revert UI so the user can try again
+      elements.pauseBtn.textContent = 'Resume';
     }
   } catch (error) {
+    elements.pauseBtn.textContent = 'Resume';
     addLogEntry('Failed to resume download', 'error');
+  } finally {
+    elements.pauseBtn.disabled = false;
+    hideProgressStatus();
   }
+}
+
+function showProgressStatus(message) {
+  if (!elements.progressStatus) return;
+  elements.progressStatus.textContent = message;
+  elements.progressStatus.style.display = 'block';
+}
+
+function hideProgressStatus() {
+  if (!elements.progressStatus) return;
+  elements.progressStatus.textContent = '';
+  elements.progressStatus.style.display = 'none';
 }
 
 async function handleStopDownload() {


### PR DESCRIPTION
## Summary
Clicking Resume on a paused queue showed no feedback until the first \`DOWNLOAD_PROGRESS\` broadcast arrived several seconds later — the service worker has to wake, await restore, unpause, and start processing before the sidepanel sees anything change. During that gap the user couldn't tell whether the click registered.

Fix:
- New \`#progressStatus\` line under the progress bar for transient operation text
- On Resume click, immediately flip the button to "Resuming...", disable it to prevent double-clicks, and show "Resuming downloads..." in the status line
- \`finally\` block reverts button state and clears the status regardless of response outcome

Closes #52.

## Test plan
- [ ] Pause an active download
- [ ] Wait ~1 minute (let the service worker go idle)
- [ ] Click Resume — button should immediately read "Resuming..." and the status line should show "Resuming downloads..."
- [ ] When the first album's progress lands, the button flips to "Pause" and the status line clears
- [ ] Rapid double-clicking Resume while disabled should be no-op (button is disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)