### PR TITLE
chore: Bump version to 1.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Trail Mix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pack light. Bring your whole Bandcamp collection.",
   "permissions": [
     "downloads",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trail-mix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Trail Mix - Chrome extension for bulk downloading Bandcamp purchases",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Summary
Bump \`manifest.json\` and \`package.json\` to \`1.2.1\` for the next Chrome Web Store release.

Ships the three fixes to the reported UX issues on large-collection downloads:
- #50 accurate progress bar (PR #53)
- #51 pause/resume no longer re-downloads completed albums (PR #54)
- #52 status text while resuming a paused download (PR #55)

## Test plan
- [ ] \`npm run package\` builds a clean zip
- [ ] Sidepanel footer reads \`v1.2.1\` (pulled dynamically from manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)